### PR TITLE
Refactor setup-gradle tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ jobs:
         cache: gradle
 
     - name: Build
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build
+      run: ./gradlew build
 
     - name: Container test
       uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION

This job uses deprecated functionality from the gradle/actions/setup-gradle action. Follow the links for upgrade details.
[Using the action to execute Gradle via the `arguments` parameter is deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)